### PR TITLE
EXO Resources: Removed elements from hashtable

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
@@ -311,6 +311,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
@@ -324,6 +324,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
@@ -604,6 +604,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
@@ -439,10 +439,19 @@ function Set-TargetResource
     $AntiPhishPolicies = Get-AntiPhishPolicy
 
     $AntiPhishPolicy = $AntiPhishPolicies | Where-Object -FilterScript { $_.Identity -eq $Identity }
+    $AntiPhishPolicyparams = $PSBoundParameters
+    $AntiPhishPolicyparams.Remove('Ensure') | Out-Null
+    $AntiPhishPolicyparams.Remove('GlobalAdminAccount') | Out-Null
+    $AntiPhishPolicyparams.Remove('MakeDefault') | Out-Null
+    $AntiPhishPolicyparams.Remove('ApplicationId') | Out-Null
+    $AntiPhishPolicyparams.Remove('TenantId') | Out-Null
+    $AntiPhishPolicyparams.Remove('CertificateThumbprint') | Out-Null
+    $AntiPhishPolicyparams.Remove('CertificatePath') | Out-Null
+    $AntiPhishPolicyparams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and (-not $AntiPhishPolicy))
     {
-        New-EXOAntiPhishPolicy -AntiPhishPolicyParams $PSBoundParameters
+        New-EXOAntiPhishPolicy -AntiPhishPolicyParams $AntiPhishPolicyparams
     }
 
     if (('Present' -eq $Ensure ) -and ($AntiPhishPolicy))
@@ -452,7 +461,7 @@ function Set-TargetResource
         # policy and recreate it in order to make sure the parameters all match the desired
         # state specified;
         Remove-AntiPhishPolicy -Identity $Identity -Confirm:$false -Force
-        New-EXOAntiPhishPolicy -AntiPhishPolicyParams $PSBoundParameters
+        New-EXOAntiPhishPolicy -AntiPhishPolicyParams $AntiPhishPolicyparams
     }
 
     if (('Absent' -eq $Ensure ) -and ($AntiPhishPolicy))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
@@ -295,11 +295,16 @@ function Set-TargetResource
 
     if ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Absent')
     {
-        $CreationParams = $PSBoundParameters
+        $CreationParams = [System.Collections.Hashtable]($PSBoundParameters)
         $CreationParams.Remove("Ensure") | Out-Null
         $CreationParams.Remove("GlobalAdminAccount") | Out-Null
         $CreationParams.Add("Name", $Identity) | Out-Null
         $CreationParams.Remove("Identity") | Out-Null
+        $CreationParams.Remove('ApplicationId') | Out-Null
+        $CreationParams.Remove('TenantId') | Out-Null
+        $CreationParams.Remove('CertificateThumbprint') | Out-Null
+        $CreationParams.Remove('CertificatePath') | Out-Null
+        $CreationParams.Remove('CertificatePassword') | Out-Null
 
         # New-AntiPhishRule has the Enabled parameter, Set-AntiPhishRule does not.
         # There doesn't appear to be any way to change the Enabled state of a rule once created.
@@ -318,6 +323,11 @@ function Set-TargetResource
         $UpdateParams.Remove("Ensure") | Out-Null
         $UpdateParams.Remove("GlobalAdminAccount") | Out-Null
         $UpdateParams.Remove("Enabled") | Out-Null
+        $UpdateParams.Remove('ApplicationId') | Out-Null
+        $UpdateParams.Remove('TenantId') | Out-Null
+        $UpdateParams.Remove('CertificateThumbprint') | Out-Null
+        $UpdateParams.Remove('CertificatePath') | Out-Null
+        $UpdateParams.Remove('CertificatePassword') | Out-Null
 
         # Check to see if the specified policy already has the rule assigned;
         $existingRule = Get-AntiPhishRule | Where-Object -FilterScript { $_.AntiPhishPolicy -eq $AntiPhishPolicy }
@@ -436,6 +446,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     if ($null -eq $PSBoundParameters.Enabled)
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
@@ -343,6 +343,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -239,10 +239,15 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Platform 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    $AtpPolicyParams = $PSBoundParameters
+    $AtpPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $AtpPolicyParams.Remove('Ensure') | Out-Null
     $AtpPolicyParams.Remove('GlobalAdminAccount') | Out-Null
     $AtpPolicyParams.Remove('IsSingleInstance') | Out-Null
+    $AtpPolicyParams.Remove('ApplicationId') | Out-Null
+    $AtpPolicyParams.Remove('TenantId') | Out-Null
+    $AtpPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $AtpPolicyParams.Remove('CertificatePath') | Out-Null
+    $AtpPolicyParams.Remove('CertificatePassword') | Out-Null
     Write-Verbose -Message "Setting AtpPolicyForO365 $Identity with values: $(Convert-M365DscHashtableToString -Hashtable $AtpPolicyParams)"
     Set-AtpPolicyForO365 @AtpPolicyParams
 }
@@ -336,6 +341,11 @@ function Test-TargetResource
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('IsSingleInstance') | Out-Null
     $ValuesToCheck.Remove('Verbose') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
@@ -238,9 +238,14 @@ function Set-TargetResource
     }
 
     $AvailabilityAddressSpace = $AvailabilityAddressSpaces | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $AvailabilityAddressSpaceParams = $PSBoundParameters
+    $AvailabilityAddressSpaceParams = [System.Collections.Hashtable]($PSBoundParameters)
     $AvailabilityAddressSpaceParams.Remove('Ensure') | Out-Null
     $AvailabilityAddressSpaceParams.Remove('GlobalAdminAccount') | Out-Null
+    $AvailabilityAddressSpaceParams.Remove('ApplicationId') | Out-Null
+    $AvailabilityAddressSpaceParams.Remove('TenantId') | Out-Null
+    $AvailabilityAddressSpaceParams.Remove('CertificateThumbprint') | Out-Null
+    $AvailabilityAddressSpaceParams.Remove('CertificatePath') | Out-Null
+    $AvailabilityAddressSpaceParams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and ($null -eq $AvailabilityAddressSpace))
     {
@@ -366,6 +371,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
@@ -254,6 +254,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $DesiredValues = $PSBoundParameters
     if ($OrgWideAccount.Contains("@"))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
@@ -213,9 +213,14 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Platform 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    $CASMailboxPlanParams = $PSBoundParameters
+    $CASMailboxPlanParams = [System.Collections.Hashtable]($PSBoundParameters)
     $CASMailboxPlanParams.Remove('Ensure') | Out-Null
     $CASMailboxPlanParams.Remove('GlobalAdminAccount') | Out-Null
+    $CASMailboxPlanParams.Remove('ApplicationId') | Out-Null
+    $CASMailboxPlanParams.Remove('TenantId') | Out-Null
+    $CASMailboxPlanParams.Remove('CertificateThumbprint') | Out-Null
+    $CASMailboxPlanParams.Remove('CertificatePath') | Out-Null
+    $CASMailboxPlanParams.Remove('CertificatePassword') | Out-Null
 
     $CASMailboxPlans = Get-CASMailboxPlan
     $CASMailboxPlan = $CASMailboxPlans | Where-Object -FilterScript { $_.Identity -eq $Identity }
@@ -305,6 +310,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
@@ -306,9 +306,14 @@ function Set-TargetResource
     $ClientAccessRules = Get-ClientAccessRule
 
     $ClientAccessRule = $ClientAccessRules | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $ClientAccessRuleParams = $PSBoundParameters
+    $ClientAccessRuleParams = [System.Collections.Hashtable]($PSBoundParameters)
     $ClientAccessRuleParams.Remove('Ensure') | Out-Null
     $ClientAccessRuleParams.Remove('GlobalAdminAccount') | Out-Null
+    $ClientAccessRuleParams.Remove('ApplicationId') | Out-Null
+    $ClientAccessRuleParams.Remove('TenantId') | Out-Null
+    $ClientAccessRuleParams.Remove('CertificateThumbprint') | Out-Null
+    $ClientAccessRuleParams.Remove('CertificatePath') | Out-Null
+    $ClientAccessRuleParams.Remove('CertificatePassword') | Out-Null
     if ($ClientAccessRuleParams.RuleScope)
     {
         $ClientAccessRuleParams += @{
@@ -452,6 +457,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
@@ -211,9 +211,14 @@ function Set-TargetResource
 
     if (('Present' -eq $Ensure ) -and ($null -eq $DkimSigningConfig))
     {
-        $DkimSigningConfigParams = $PSBoundParameters
+        $DkimSigningConfigParams = [System.Collections.Hashtable]($PSBoundParameters)
         $DkimSigningConfigParams.Remove('Ensure') | Out-Null
         $DkimSigningConfigParams.Remove('GlobalAdminAccount') | Out-Null
+        $DkimSigningConfigParams.Remove('ApplicationId') | Out-Null
+        $DkimSigningConfigParams.Remove('TenantId') | Out-Null
+        $DkimSigningConfigParams.Remove('CertificateThumbprint') | Out-Null
+        $DkimSigningConfigParams.Remove('CertificatePath') | Out-Null
+        $DkimSigningConfigParams.Remove('CertificatePassword') | Out-Null
         $DkimSigningConfigParams += @{
             DomainName = $PSBoundParameters.Identity
         }
@@ -319,6 +324,12 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
+
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
@@ -344,6 +344,12 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
+
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
@@ -597,6 +597,12 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
+
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
@@ -236,10 +236,15 @@ function Set-TargetResource
 
     $HostedConnectionFilterPolicy = $HostedConnectionFilterPolicys | Where-Object -FilterScript { $_.Identity -eq $Identity }
 
-    $HostedConnectionFilterPolicyParams = $PSBoundParameters
+    $HostedConnectionFilterPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $HostedConnectionFilterPolicyParams.Remove('Ensure') | Out-Null
     $HostedConnectionFilterPolicyParams.Remove('GlobalAdminAccount') | Out-Null
     $HostedConnectionFilterPolicyParams.Remove('MakeDefault') | Out-Null
+    $HostedConnectionFilterPolicyParams.Remove('ApplicationId') | Out-Null
+    $HostedConnectionFilterPolicyParams.Remove('TenantId') | Out-Null
+    $HostedConnectionFilterPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $HostedConnectionFilterPolicyParams.Remove('CertificatePath') | Out-Null
+    $HostedConnectionFilterPolicyParams.Remove('CertificatePassword') | Out-Null
 
     if ($HostedConnectionFilterPolicyParams.RuleScope)
     {
@@ -362,6 +367,12 @@ function Test-TargetResource
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('IsSingleInstance') | Out-Null
     $ValuesToCheck.Remove('Verbose') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
+
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -651,10 +651,15 @@ function Set-TargetResource
     $HostedContentFilterPolicies = Get-HostedContentFilterPolicy
 
     $HostedContentFilterPolicy = $HostedContentFilterPolicies | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $HostedContentFilterPolicyParams = $PSBoundParameters
+    $HostedContentFilterPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $HostedContentFilterPolicyParams.Remove('Ensure') | Out-Null
     $HostedContentFilterPolicyParams.Remove('GlobalAdminAccount') | Out-Null
     $HostedContentFilterPolicyParams.Remove('MakeDefault') | Out-Null
+    $HostedContentFilterPolicyParams.Remove('ApplicationId') | Out-Null
+    $HostedContentFilterPolicyParams.Remove('TenantId') | Out-Null
+    $HostedContentFilterPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $HostedContentFilterPolicyParams.Remove('CertificatePath') | Out-Null
+    $HostedContentFilterPolicyParams.Remove('CertificatePassword') | Out-Null
 
     if ($HostedContentFilterPolicyParams.Contains('EndUserSpamNotificationCustomFromAddress'))
     {
@@ -969,6 +974,11 @@ function Test-TargetResource
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('EndUserSpamNotificationCustomFromAddress') | Out-Null
     $ValuesToCheck.Remove('EndUserSpamNotificationCustomFromName') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
@@ -293,6 +293,11 @@ function Set-TargetResource
         $CreationParams = $PSBoundParameters
         $CreationParams.Remove("Ensure") | Out-Null
         $CreationParams.Remove("GlobalAdminAccount") | Out-Null
+        $CreationParams.Remove('ApplicationId') | Out-Null
+        $CreationParams.Remove('TenantId') | Out-Null
+        $CreationParams.Remove('CertificateThumbprint') | Out-Null
+        $CreationParams.Remove('CertificatePath') | Out-Null
+        $CreationParams.Remove('CertificatePassword') | Out-Null
         if ($Enabled -and ('Disabled' -eq $CurrentValues.State))
         {
             # New-HostedContentFilterRule has the Enabled parameter, Set-HostedContentFilterRule does not.
@@ -307,9 +312,14 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Present' -and $CurrentValues -eq 'Present')
     {
-        $UpdateParams = $PSBoundParameters
+        $UpdateParams = [System.Collections.Hashtable]($PSBoundParameters)
         $UpdateParams.Remove("Ensure") | Out-Null
         $UpdateParams.Remove("GlobalAdminAccount") | Out-Null
+        $UpdateParams.Remove('ApplicationId') | Out-Null
+        $UpdateParams.Remove('TenantId') | Out-Null
+        $UpdateParams.Remove('CertificateThumbprint') | Out-Null
+        $UpdateParams.Remove('CertificatePath') | Out-Null
+        $UpdateParams.Remove('CertificatePassword') | Out-Null
         Write-Verbose -Message "Updating HostedContentFilterRule {$Identity}"
         Set-HostedContentFilterRule @UpdateParams
     }
@@ -418,6 +428,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
@@ -214,9 +214,14 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Platform 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    $HostedOutboundSpamFilterPolicyParams = $PSBoundParameters
+    $HostedOutboundSpamFilterPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $HostedOutboundSpamFilterPolicyParams.Remove('Ensure') | Out-Null
     $HostedOutboundSpamFilterPolicyParams.Remove('GlobalAdminAccount') | Out-Null
+    $HostedOutboundSpamFilterPolicyParams.Remove('ApplicationId') | Out-Null
+    $HostedOutboundSpamFilterPolicyParams.Remove('TenantId') | Out-Null
+    $HostedOutboundSpamFilterPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $HostedOutboundSpamFilterPolicyParams.Remove('CertificatePath') | Out-Null
+    $HostedOutboundSpamFilterPolicyParams.Remove('CertificatePassword') | Out-Null
 
     Write-Verbose -Message "Setting HostedOutboundSpamFilterPolicy $Identity with values: $(Convert-M365DscHashtableToString -Hashtable $HostedOutboundSpamFilterPolicyParams)"
     Set-HostedOutboundSpamFilterPolicy @HostedOutboundSpamFilterPolicyParams
@@ -301,6 +306,11 @@ function Test-TargetResource
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('Verbose') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
@@ -301,6 +301,11 @@ function Set-TargetResource
     $InboundConnectorParams = $PSBoundParameters
     $InboundConnectorParams.Remove('Ensure') | Out-Null
     $InboundConnectorParams.Remove('GlobalAdminAccount') | Out-Null
+    $InboundConnectorParams.Remove('ApplicationId') | Out-Null
+    $InboundConnectorParams.Remove('TenantId') | Out-Null
+    $InboundConnectorParams.Remove('CertificateThumbprint') | Out-Null
+    $InboundConnectorParams.Remove('CertificatePath') | Out-Null
+    $InboundConnectorParams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and ($null -eq $InboundConnector))
     {
@@ -433,6 +438,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
@@ -198,9 +198,14 @@ function Set-TargetResource
 
     $IntraOrganizationConnectors = Get-IntraOrganizationConnector
     $IntraOrganizationConnector = $IntraOrganizationConnectors | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $IntraOrganizationConnectorParams = $PSBoundParameters
+    $IntraOrganizationConnectorParams = [System.Collections.Hashtable]($PSBoundParameters)
     $IntraOrganizationConnectorParams.Remove('Ensure') | Out-Null
     $IntraOrganizationConnectorParams.Remove('GlobalAdminAccount') | Out-Null
+    $IntraOrganizationConnectorParams.Remove('ApplicationId') | Out-Null
+    $IntraOrganizationConnectorParams.Remove('TenantId') | Out-Null
+    $IntraOrganizationConnectorParams.Remove('CertificateThumbprint') | Out-Null
+    $IntraOrganizationConnectorParams.Remove('CertificatePath') | Out-Null
+    $IntraOrganizationConnectorParams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and ($null -eq $IntraOrganizationConnector))
     {
@@ -291,6 +296,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
@@ -362,9 +362,14 @@ function Set-TargetResource
 
     $MalwareFilterPolicys = Get-MalwareFilterPolicy
     $MalwareFilterPolicy = $MalwareFilterPolicys | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $MalwareFilterPolicyParams = $PSBoundParameters
+    $MalwareFilterPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $MalwareFilterPolicyParams.Remove('Ensure') | Out-Null
     $MalwareFilterPolicyParams.Remove('GlobalAdminAccount') | Out-Null
+    $MalwareFilterPolicyParams.Remove('ApplicationId') | Out-Null
+    $MalwareFilterPolicyParams.Remove('TenantId') | Out-Null
+    $MalwareFilterPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $MalwareFilterPolicyParams.Remove('CertificatePath') | Out-Null
+    $MalwareFilterPolicyParams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and ($null -eq $MalwareFilterPolicy))
     {
@@ -525,6 +530,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
@@ -263,9 +263,14 @@ function Set-TargetResource
 
     $MalwareFilterRules = Get-MalwareFilterRule
     $MalwareFilterRule = $MalwareFilterRules | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $MalwareFilterRuleParams = $PSBoundParameters
+    $MalwareFilterRuleParams = [System.Collections.Hashtable]($PSBoundParameters)
     $MalwareFilterRuleParams.Remove('Ensure') | Out-Null
     $MalwareFilterRuleParams.Remove('GlobalAdminAccount') | Out-Null
+    $MalwareFilterRuleParams.Remove('ApplicationId') | Out-Null
+    $MalwareFilterRuleParams.Remove('TenantId') | Out-Null
+    $MalwareFilterRuleParams.Remove('CertificateThumbprint') | Out-Null
+    $MalwareFilterRuleParams.Remove('CertificatePath') | Out-Null
+    $MalwareFilterRuleParams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and ($null -eq $MalwareFilterRule))
     {
@@ -385,6 +390,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
@@ -292,6 +292,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
@@ -1045,6 +1045,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
@@ -333,6 +333,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
@@ -368,6 +368,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
@@ -762,9 +762,14 @@ function Set-TargetResource
 
 
     Write-Verbose -Message "Setting EXOOrganizationConfig with values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
-    $SetValues = $PSBoundParameters
-    $SetValues.Remove('IsSingleInstance')
-    $SetValues.Remove('GlobalAdminAccount')
+    $SetValues = [System.Collections.Hashtable]($PSBoundParameters)
+    $SetValues.Remove('IsSingleInstance') | Out-Null
+    $SetValues.Remove('GlobalAdminAccount') | Out-Null
+    $SetValues.Remove('ApplicationId') | Out-Null
+    $SetValues.Remove('TenantId') | Out-Null
+    $SetValues.Remove('CertificateThumbprint') | Out-Null
+    $SetValues.Remove('CertificatePath') | Out-Null
+    $SetValues.Remove('CertificatePassword') | Out-Null
     Set-OrganizationConfig @SetValues
 }
 
@@ -1081,6 +1086,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -563,6 +563,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
@@ -320,9 +320,14 @@ function Set-TargetResource
 
     $OutBoundConnectors = Get-OutBoundConnector
     $OutBoundConnector = $OutBoundConnectors | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $OutBoundConnectorParams = $PSBoundParameters
+    $OutBoundConnectorParams = [System.Collections.Hashtable]($PSBoundParameters)
     $OutBoundConnectorParams.Remove('Ensure') | Out-Null
     $OutBoundConnectorParams.Remove('GlobalAdminAccount') | Out-Null
+    $OutBoundConnectorParams.Remove('ApplicationId') | Out-Null
+    $OutBoundConnectorParams.Remove('TenantId') | Out-Null
+    $OutBoundConnectorParams.Remove('CertificateThumbprint') | Out-Null
+    $OutBoundConnectorParams.Remove('CertificatePath') | Out-Null
+    $OutBoundConnectorParams.Remove('CertificatePassword') | Out-Null
 
 
     if (('Present' -eq $Ensure ) -and ($null -eq $OutBoundConnector))
@@ -466,6 +471,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -1337,6 +1337,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
@@ -343,6 +343,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
@@ -287,6 +287,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
@@ -371,12 +371,14 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Platform 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    $RemoteDomainParams = $PSBoundParameters
+    $RemoteDomainParams = [System.Collections.Hashtable]($PSBoundParameters)
     $RemoteDomainParams.Remove("GlobalAdminAccount") | Out-Null
     $RemoteDomainParams.Remove("Ensure") | Out-Null
     $RemoteDomainParams.Remove("ApplicationId") | Out-Null
     $RemoteDomainParams.Remove("TenantId") | Out-Null
     $RemoteDomainParams.Remove("CertificateThumbprint") | Out-Null
+    $RemoteDomainParams.Remove('CertificatePath') | Out-Null
+    $RemoteDomainParams.Remove('CertificatePassword') | Out-Null
 
     # CASE: Remote Domain doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentRemoteDomainConfig.Ensure -eq "Absent")
@@ -557,6 +559,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
@@ -323,6 +323,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
@@ -226,9 +226,15 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Platform 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    $SafeAttachmentPolicyParams = $PSBoundParameters
+    $SafeAttachmentPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $SafeAttachmentPolicyParams.Remove('Ensure') | Out-Null
     $SafeAttachmentPolicyParams.Remove('GlobalAdminAccount') | Out-Null
+    $SafeAttachmentPolicyParams.Remove('ApplicationId') | Out-Null
+    $SafeAttachmentPolicyParams.Remove('TenantId') | Out-Null
+    $SafeAttachmentPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $SafeAttachmentPolicyParams.Remove('CertificatePath') | Out-Null
+    $SafeAttachmentPolicyParams.Remove('CertificatePassword') | Out-Null
+
     $SafeAttachmentPolicies = Get-SafeAttachmentPolicy
 
     $SafeAttachmentPolicy = $SafeAttachmentPolicies | Where-Object -FilterScript { $_.Identity -eq $Identity }
@@ -340,6 +346,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
@@ -411,6 +411,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
@@ -266,9 +266,14 @@ function Set-TargetResource
     $SafeLinksPolicies = Get-SafeLinksPolicy
 
     $SafeLinksPolicy = $SafeLinksPolicies | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $SafeLinksPolicyParams = $PSBoundParameters
+    $SafeLinksPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $SafeLinksPolicyParams.Remove('Ensure') | Out-Null
     $SafeLinksPolicyParams.Remove('GlobalAdminAccount') | Out-Null
+    $SafeLinksPolicyParams.Remove('ApplicationId') | Out-Null
+    $SafeLinksPolicyParams.Remove('TenantId') | Out-Null
+    $SafeLinksPolicyParams.Remove('CertificateThumbprint') | Out-Null
+    $SafeLinksPolicyParams.Remove('CertificatePath') | Out-Null
+    $SafeLinksPolicyParams.Remove('CertificatePassword') | Out-Null
 
     if (('Present' -eq $Ensure ) -and ($null -eq $SafeLinksPolicy))
     {
@@ -387,6 +392,11 @@ function Test-TargetResource
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('IsSingleInstance') | Out-Null
     $ValuesToCheck.Remove('Verbose') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
@@ -399,6 +399,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
@@ -313,6 +313,11 @@ function Test-TargetResource
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `


### PR DESCRIPTION
At the Test-TargetResource I' did the follwoing additions:
    $ValuesToCheck.Remove('ApplicationId') | Out-Null
    $ValuesToCheck.Remove('TenantId') | Out-Null
    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
    $ValuesToCheck.Remove('CertificatePath') | Out-Null
    $ValuesToCheck.Remove('CertificatePassword') | Out-Null

So these values will not be checked during Test-TargetResource, I added it for all EXO Resources where it was needed

I've also removed the ApplicationID, TenantID, CertificateThumbprint, CertificatePath and CertificatePassword from the $PSBoundParameters of following resources in the Set-TargetResource and I made sure that these parameters will be in a Hashtable bij defining it as [System.Collections.Hashtable]($PSBoundParameters) for the ones that needed it.:
MSFT_EXODkimSigningConfig
MSFT_EXOClientAccessRule
MSFT_EXOCASMailboxPlan
MSFT_EXOAvailabilityAddressSpace
MSFT_EXOAtpPolicyForO365
MSFT_EXOAntiPhishRule
MSFT_EXOHostedContentFilterRule
MSFT_EXOHostedOutboundSpamFilterPolicy
MSFT_EXOInboundConnector
MSFT_EXOIntraOrganizationConnector
MSFT_EXOMalwareFilterPolicy
MSFT_EXOMalwareFilterRule
MSFT_EXOOrganizationConfig
MSFT_EXOOutboundConnector
MSFT_EXOSafeLinksPolicy
MSFT_EXOSafeAttachmentPolicy
MSFT_EXORemoteDomain


- fixes #1100
- fixes #1140
